### PR TITLE
Custom validation error messages

### DIFF
--- a/lib/context_validations/controller.rb
+++ b/lib/context_validations/controller.rb
@@ -63,7 +63,7 @@ module ContextValidations::Controller
   private
 
   def _validates_default_keys
-    [:if, :unless, :on, :allow_blank, :allow_nil , :strict]
+    [:if, :unless, :on, :allow_blank, :allow_nil , :strict, :message]
   end
 
   def _parse_validates_options(options)


### PR DESCRIPTION
Adds :message to _validates_default_keys. Allows for custom validation error messages.
